### PR TITLE
feat: 일정 구분별 색 표시 기능 추가

### DIFF
--- a/momentours-front/src/components/schedule/Calendar.vue
+++ b/momentours-front/src/components/schedule/Calendar.vue
@@ -31,6 +31,7 @@
 </script>
 
 <style scoped>
+
     .vuecal--month-view .vuecal__cell {
         height: 50px;
     }
@@ -47,4 +48,5 @@
 .vuecal--month-view .vuecal__no-event {
     display: none;
     } 
+
 </style>

--- a/momentours-front/src/views/schedule/ScheduleEdit.vue
+++ b/momentours-front/src/views/schedule/ScheduleEdit.vue
@@ -1,16 +1,20 @@
 <template>
 <div class="container">
     <template v-if="localEvent.clickType === 'Schedule'">
-        <template v-if="localEvent.contentType === 'schedule'">
+        <template v-if="localEvent.class === 'schedule'">
             <div class="content-box">
-                <h2>일정제목: </h2>
+                <p>일정제목 </p>
                 <input v-model="localEvent.title" />
-                <h2>일정메모: </h2>
+                <hr>
+                <p>일정메모</p>
                 <input v-model="localEvent.content" />
-                <h2>일정시작일: </h2>
+                <hr>
+                <p>일정시작일</p>
                 <input type="date" v-model="localEvent.start"/>
-                <h2>일정종료일: </h2>
+                <hr>
+                <p>일정종료일</p>
                 <input type="date" v-model="localEvent.end"/>
+                <hr>
                 <div class="button-box">
                     <button class="common-button" type="button" @click="submitEvent">수정하기</button>
                     <button class="common-button" type="button" @click="goToViewPage">뒤로가기</button>
@@ -18,14 +22,16 @@
             </div>
         </template>
 
-        <template v-if="localEvent.contentType === 'todocourse'">
+        <template v-if="localEvent.class === 'todocourse'">
             <div class="content-box">
             <h3>일정제목: {{ localEvent.title }}</h3>
             <h3>일정메모: {{ localEvent.content }}</h3>
             <h3>일정시작일: {{ localEvent.start }}</h3>
             <h3>일정종료일: {{ localEvent.end }}</h3>
-            <button @click="goToTodoCourseEdit">예정코스 수정하러가기</button>
-            <br><br><br>
+            <div class="button-box">
+            <button class="common-button" @click="goToTodoCourseEdit">예정코스 수정하러가기</button>
+            <button class="common-button" @click="goToViewPage">뒤로가기</button>
+        </div>
             </div>
         </template>
     </template>
@@ -95,6 +101,7 @@ const goToViewPage = ()=>{
     border-radius: 8px; /* 모서리 둥글게 */
     background-color: white; /* 배경색 */
     box-shadow: 0 4px 10px rgba(0, 0, 0, 0.1); /* 그림자 효과 */
+    
 
     
 }

--- a/momentours-front/src/views/schedule/ScheduleRegist.vue
+++ b/momentours-front/src/views/schedule/ScheduleRegist.vue
@@ -1,16 +1,16 @@
 <template>
     <div class="regist-container">
     <div class="regist-box">
-        <h2>일정 제목:</h2>
+        <p>일정 제목</p>
         <input v-model="localEvent.title" />
-
-        <h2>일정 메모:</h2>
+        <hr>
+        <p>일정 메모</p>
         <input v-model="localEvent.content" />
-
-        <h2>일정 시작일:</h2>
+        <hr>
+        <p>일정 시작일</p>
         <input type="date" v-model="localEvent.start" />
-
-        <h2>일정 종료일:</h2>
+        <hr>
+        <p>일정 종료일</p>
         <input type="date" v-model="localEvent.end" />
 
         <div class="button-box">
@@ -32,7 +32,7 @@ const localEvent = reactive({
     content: '',
     start: '',
     end: '',
-    contentType:"schedule"
+    class:"schedule"
 });
 
 const emit = defineEmits(['update:regist']);

--- a/momentours-front/src/views/schedule/ScheduleRoot.vue
+++ b/momentours-front/src/views/schedule/ScheduleRoot.vue
@@ -41,7 +41,7 @@ return [...schedules,...metdays,...todocourses];
 };
 
 const jsonEdit = async() => {
-    await fetch(`http://localhost:8080/${event.contentType}/${event.id}`,{
+    await fetch(`http://localhost:8080/${event.class}/${event.id}`,{
         method: "PUT",
         body: JSON.stringify({
             "id":`${event.id}`,
@@ -49,7 +49,7 @@ const jsonEdit = async() => {
             "end":`${event.end}`,
             "title":`${event.title}`,
             "content":`${event.content}`,
-            "contentType":`${event.contentType}`
+            "class":`${event.class}`
         })
     });
     const newEvents = await jsonView();
@@ -74,7 +74,7 @@ const jsonRegist = async(newEvent)=>{
             "end":`${newEvent.end}`,
             "title":`${newEvent.title}`,
             "content":`${newEvent.content}`,
-            "contentType":`${newEvent.contentType}`
+            "class":`${newEvent.class}`
         })
     })
     const newEvents = await jsonView();
@@ -95,7 +95,7 @@ try {
 }
 });
 
-const event = reactive({id:'', title:'', content:'', start:'', end:'', clickType:'', selectedDay:'', contentType:''});
+const event = reactive({id:'', title:'', content:'', start:'', end:'', clickType:'', selectedDay:'', class:''});
 const dayEvents = reactive([]);
 
 const eventClicked = (clickEvent) => {
@@ -105,7 +105,7 @@ Object.assign(event, {
     content: clickEvent.content,
     start: formatDate(clickEvent.start),
     end: formatDate(clickEvent.end),
-    contentType: clickEvent.contentType,
+    class: clickEvent.class,
     clickType: "Schedule"
 });
 };
@@ -142,7 +142,7 @@ const handleRemove = () => {
     event.end = '';
     event.clickType = '';
     event.selectedDay = '';
-    event.contentType = '';
+    event.class = '';
 };
 
 const handleRegist = (newEvent) => {
@@ -158,6 +158,7 @@ const handleRegist = (newEvent) => {
 </script>
 
 <style scoped>
+
 .flex-container {
 display: flex;
 padding: 2rem;
@@ -199,4 +200,26 @@ overflow: auto;
     height: auto;
 }
 }
+:deep(.vuecal__event.schedule) {
+    background-color: rgba(167, 255, 217, 0.9);
+    border: 1px solid rgb(205, 253, 255);
+    }
+
+:deep(.vuecal__event.todocourse) {
+        background-color: #ffeab2;
+    border: 1px solid rgb(241, 224, 173);
+    color: #000000;
+}
+
+:deep(.vuecal__event.memorial) {
+        background-color: #FFC7C7;
+    border: 1px solid rgb(241, 182, 182);
+    color: #2b2b2b;
+}
+
+.main-box {
+    position: relative;
+    top:20vh;
+}
+
 </style>

--- a/momentours-front/src/views/schedule/ScheduleView.vue
+++ b/momentours-front/src/views/schedule/ScheduleView.vue
@@ -1,16 +1,16 @@
 <template>
-    
+<div class="main-box">
     <div class="board-box-schedule" v-if="event.clickType == 'Schedule'">
-        <h2 class="title">일정 제목: {{ event.title }}</h2>
-        <h2 class="content">일정 메모: {{ event.content }}</h2>
-        <h2 class="date">일정 시작일: {{ event.start }}</h2>
-        <h2 class="date">일정 종료일: {{ event.end }}</h2>
+        <p class="title">일정 제목: {{ event.title }}</p>
+        <p class="content">일정 메모: {{ event.content }}</p>
+        <p class="date">일정 시작일: {{ event.start }}</p>
+        <p class="date">일정 종료일: {{ event.end }}</p>
         
-        <div v-if="event.contentType == 'schedule'" class="action-buttons">
+        <div v-if="event.class == 'schedule'" class="action-buttons">
             <button class="common-button edit" @click="toEditRouter">수정</button>
             <button class="common-button delete" @click="toRemoveRouter">삭제</button>
         </div>
-        <div v-if="event.contentType == 'todocourse'" class="action-buttons">
+        <div v-if="event.class == 'todocourse'" class="action-buttons">
             <button class="common-button delete" @click="toTodoCourseRouter">예정데이트코스</button>
         </div>
 
@@ -29,10 +29,9 @@
 
     <div class="board-box-no-event" v-if="event.clickType == 'Day' && dayEvents.length == 0">
         <h2 class="no-event">이 날의 일정이 없습니다</h2>
-
     </div>
-    <div class="button-container">
-        <button class="common-button" @click="toRegistRouter">등록</button>
+
+        <button class="common-button regist" @click="toRegistRouter">등록</button>
     </div>
 </template>
 
@@ -58,7 +57,7 @@ function dayEventClicked(clickedEvent) {
         content: clickedEvent.content,
         start: formatDate(clickedEvent.start),
         end: formatDate(clickedEvent.end),
-        contentType: clickedEvent.contentType,
+        class: clickedEvent.class,
         clickType: 'Schedule'
     });
 }
@@ -85,6 +84,12 @@ function toTodoCourseRouter(){
 
 
 <style scoped>
+
+.main-box {
+    position: relative;
+    top:20vh;
+}
+
 [class^="board-box"] {
     display: flex; /* flexbox 사용 */
     flex-direction: column; /* 세로 방향으로 정렬 */
@@ -175,5 +180,14 @@ function toTodoCourseRouter(){
 
 .common-button.delete:hover {
     background-color: #f572ce;
+}
+
+.common-button.regist {
+    background-color:  #c5fdd1;
+    width: 7vw;
+}
+
+.common-button.regist:hover {
+    background-color: #8bee5d;
 }
 </style>


### PR DESCRIPTION
---
name: feat: 일정 구분별 색 표시 기능 추가
about: 일정 / 예정데이트코스 / 기념일 각각 다른 색으로 달력에 표시되도록 기능 추가 / 글씨체, 버튼 색상 등 수정
title: ''
labels: enhancement
assignees: ''

---

## 무슨 이유로 코드를 변경했는가
- [x] 신규 기능
- [ ] 기능 수정
- [ ] 버그 픽스

## 어떤 위험이나 장애가 발견되었는지 (버그 픽스인 경우)
- 
- 

## 어떤 부분에 리뷰어가 집중하면 좋은가
- 색,폰트,크기 등 디자인 요소 변경할 점 있으면 코멘트 부탁드립니다!!

## 관련 스크린 샷 
![image](https://github.com/user-attachments/assets/1babe6db-7a47-4efc-a001-85f0e905b576)

## 테스트 계획 또는 완료 사항
- [ ] 테스트항목 1
- [ ] 테스트항목 2
