### PR TITLE
refactor: 헤더와 사이드바 라우팅 클릭 범위 조정

### DIFF
--- a/momentours-front/src/components/common/Header.vue
+++ b/momentours-front/src/components/common/Header.vue
@@ -3,11 +3,11 @@
       <button class="menu-icon" @click="$emit('toggle-sidebar')">
         ☰
       </button>
-      <div class="logo">
+      <div class="logo" @click="toHomeRouter">
         <img src="@/assets/icons/momentours-logo.svg" alt="Momentours icon" class="logo-icon" />
         <span class="oooh-baby-regular">Momentours</span>
       </div>
-      <div class="profile">
+      <div class="profile" @click="toMyPageRouter">
         <img src="@/assets/icons/user-profile-image.svg" alt="Profile" class="profile-image" />
         <div class="profile-info">
           <span class="profile-name">Moni Roy</span>
@@ -18,7 +18,16 @@
   </template>
   
   <script setup>
+  import { useRouter } from 'vue-router';
+  const router = useRouter();
   defineEmits(['toggle-sidebar']);
+  const toHomeRouter = ()=>{
+    router.push('/');
+};
+
+  const toMyPageRouter = ()=>{
+    router.push('/mypage');
+  };
   </script>
   
   <style scoped>
@@ -46,6 +55,8 @@
     position: absolute;
     left: 50%;
     transform: translateX(-50%);
+    cursor: pointer; 
+    user-select: none; 
   }
   
   .logo-icon {
@@ -63,6 +74,7 @@
   .profile {
     display: flex;
     align-items: center;
+    cursor: pointer;
   }
   
   .profile-image {

--- a/momentours-front/src/components/common/Sidebar.vue
+++ b/momentours-front/src/components/common/Sidebar.vue
@@ -2,29 +2,37 @@
   <div class="sidebar-overlay" v-if="isActive" @click="closeSidebar">
     <div class="sidebar" @click.stop>
       <div class="logo-container">
-    <div class="momentours-logo">
+    <div class="momentours-logo" @click="toHomeRouter">
       <img src="@/assets/icons/momentours-logo.svg" alt="logo" class="logo-icon">
     </div>
-    <div class="momentours">Momentours</div>
+    <div class="momentours" @click="toHomeRouter">Momentours</div>
   </div>
   <div class="menu-container">
-    <div class="sidebar_divider"></div>
-    <div class="menu-item"><RouterLink class="link-button" to="/" replace>홈</RouterLink></div>
-    <div class="sidebar_divider"></div>
-    <div class="menu-item"><RouterLink class="link-button" to="/mypage">마이페이지</RouterLink></div>
-    <div class="menu-item"><RouterLink class="link-button" to="/couplepage">커플페이지</RouterLink></div>
-    <div class="sidebar_divider"></div>
-    <div class="pages">PAGES</div>
-    <div class="menu-item"><RouterLink class="link-button" to="/moment">추억</RouterLink></div>
-    <div class="menu-item"><RouterLink class="link-button" to="/momentcourse">추억코스</RouterLink></div>
-    <div class="menu-item"><RouterLink class="link-button" to="/todocourse">예정데이트코스</RouterLink></div>
-    <div class="menu-item"><RouterLink class="link-button" to="/diary">일기</RouterLink></div>
-    <div class="menu-item"><RouterLink class="link-button" to="/randomquestion">랜덤질문</RouterLink></div>
-    <div class="menu-item2"><RouterLink class="link-button"to="/schedule" replace>일정</RouterLink></div>
-    <div class="sidebar_divider"></div>
-    <div class="menu-item">공지</div>
-    <div class="menu-item">로그아웃</div>
-  </div>
+  <div class="sidebar_divider"></div>
+  
+  <RouterLink class="menu-item link-button" to="/" replace>홈</RouterLink>
+  <div class="sidebar_divider"></div>
+  
+  <RouterLink class="menu-item link-button" to="/mypage">마이페이지</RouterLink>
+  <RouterLink class="menu-item link-button" to="/couplepage">커플페이지</RouterLink>
+  
+  <div class="sidebar_divider"></div>
+  
+  <div class="pages">PAGES</div>
+  
+  <RouterLink class="menu-item link-button" to="/moment">추억</RouterLink>
+  <RouterLink class="menu-item link-button" to="/momentcourse">추억코스</RouterLink>
+  <RouterLink class="menu-item link-button" to="/todocourse">예정데이트코스</RouterLink>
+  <RouterLink class="menu-item link-button" to="/diary">일기</RouterLink>
+  <RouterLink class="menu-item link-button" to="/randomquestion">랜덤질문</RouterLink>
+  
+  <RouterLink class="menu-item2 link-button" to="/schedule" replace>일정</RouterLink>
+  
+  <div class="sidebar_divider"></div>
+  
+  <div class="menu-item">공지</div>
+  <div class="menu-item" @click="logoutAndHome">로그아웃</div>
+</div>
     </div>
   </div>
 </template>
@@ -37,6 +45,17 @@ const emit = defineEmits(['close']);
 
 const closeSidebar = () => {
   emit('close');
+};
+
+const logoutAndHome = () =>{
+  window.alert("로그아웃 되었습니다!");
+  router.push('/');
+}
+
+import { useRouter } from 'vue-router';
+  const router = useRouter();
+  const toHomeRouter = ()=>{
+    router.push('/');
 };
 </script>
 
@@ -51,5 +70,17 @@ const closeSidebar = () => {
 .menu-item:hover :deep(a),
 .menu-item:hover :deep(*) {
   color: #FFFFFF;
+}
+.link-button {
+  text-decoration: none;
+
+}
+.momentours{
+  cursor: pointer;
+  transition: all 0.3s ease;
+}
+.momentours-logo{
+  cursor: pointer;
+  transition: all 0.3s ease;
 }
 </style>


### PR DESCRIPTION

---
name: refactor: 헤더와 사이드바 라우팅 클릭 범위 조정
about: 클릭 시 이동되는 부분이 시각적으로 표시되는 부분과 일치되도록 수정
 - 글씨가 표시되는 갈색 영역 클릭 시 이동
 -  프로필 사진/이름 누르면 마이페이지로 이동

title: ''
labels: enhancement
assignees: ''

---

## 무슨 이유로 코드를 변경했는가
- [ ] 신규 기능
- [x] 기능 수정
- [ ] 버그 픽스

## 어떤 위험이나 장애가 발견되었는지 (버그 픽스인 경우)
- 
- 

## 어떤 부분에 리뷰어가 집중하면 좋은가
- 잘 이동되는지 한번씩 확인 부탁드립니다!

## 관련 스크린 샷 
![image](https://github.com/user-attachments/assets/bd1d34c8-7427-465c-9033-df4fb78a193f)

## 테스트 계획 또는 완료 사항
- [ ] 테스트항목 1
- [ ] 테스트항목 2
